### PR TITLE
Fix unspecific cache key for repo config

### DIFF
--- a/gradle/changelog/wrong_repo_config.yaml
+++ b/gradle/changelog/wrong_repo_config.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix unspecific cache key for repo config ([#6](https://github.com/scm-manager/scm-file-lock-plugin/pull/6))

--- a/src/main/js/config/RepoConfig.tsx
+++ b/src/main/js/config/RepoConfig.tsx
@@ -33,8 +33,10 @@ import {
 import React, { FC, useState } from "react";
 import { FileLockConfig, useFileLockConfig, useUpdateFileLockConfig } from "./useFileLockConfig";
 import { useTranslation } from "react-i18next";
+import { Repository } from "@scm-manager/ui-types";
 
 type Props = {
+  repository: Repository;
   link: string;
 };
 
@@ -83,8 +85,8 @@ const RepoConfigEditor: FC<EditorProps> = ({ data }) => {
   );
 };
 
-const RepoConfig: FC<Props> = ({ link }) => {
-  const { data, error, isLoading } = useFileLockConfig(link);
+const RepoConfig: FC<Props> = ({ link, repository }) => {
+  const { data, error, isLoading } = useFileLockConfig(repository, link);
 
   if (isLoading) {
     return <Loading />;

--- a/src/main/js/config/useFileLockConfig.ts
+++ b/src/main/js/config/useFileLockConfig.ts
@@ -23,15 +23,16 @@
  */
 import { useMutation, useQueryClient, useQuery } from "react-query";
 import { apiClient } from "@scm-manager/ui-components";
-import { HalRepresentation, Link } from "@scm-manager/ui-types";
+import { HalRepresentation, Link, Repository } from "@scm-manager/ui-types";
 
 export type FileLockConfig = HalRepresentation & {
   enabled: boolean;
 };
 
-export const useFileLockConfig = (link: string) => {
-  const { error, isLoading, data } = useQuery<FileLockConfig, Error>("fileLockConfig", () =>
-    apiClient.get(link).then(res => res.json())
+export const useFileLockConfig = (repository: Repository, link: string) => {
+  const { error, isLoading, data } = useQuery<FileLockConfig, Error>(
+    [repository.namespace, repository.name, "fileLockConfig"],
+    () => apiClient.get(link).then(res => res.json())
   );
 
   return {

--- a/src/main/js/config/useFileLockConfig.ts
+++ b/src/main/js/config/useFileLockConfig.ts
@@ -31,7 +31,7 @@ export type FileLockConfig = HalRepresentation & {
 
 export const useFileLockConfig = (repository: Repository, link: string) => {
   const { error, isLoading, data } = useQuery<FileLockConfig, Error>(
-    [repository.namespace, repository.name, "fileLockConfig"],
+    ["file-lock-config", repository.namespace, repository.name],
     () => apiClient.get(link).then(res => res.json())
   );
 
@@ -54,7 +54,7 @@ export const useUpdateFileLockConfig = () => {
     },
     {
       onSuccess: () => {
-        return queryClient.invalidateQueries(["fileLockConfig"]);
+        return queryClient.invalidateQueries(["file-lock-config"]);
       }
     }
   );


### PR DESCRIPTION
## Proposed changes

An unspecific cache key led to the same file-lock config for all repository and also could send wrong requests because the update url of the cached repo config was used regardless which repo was updated.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
